### PR TITLE
add version parameter

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,10 +23,14 @@
           # Function requires a derivation along with it's meta data instead
           # of a built store path provided by `nix bundle`
           package = program: system: let
-            name= (parseDrvName ( elemAt (split "/[0-9a-df-np-sv-z]{32}-" (program)) 2)).name;
-            in (pkgs system).runCommand name {} ''
-             mkdir -p $out/bin
-             ln -s ${program} $out/bin/.
+            derivation = parseDrvName (
+              elemAt (split "/" (elemAt (split "/[0-9a-df-np-sv-z]{32}-" (program)) 2)) 0
+            );
+            name = derivation.name;
+            version = if derivation.version != "" then derivation.version else "1.0";
+          in (pkgs system).runCommand name { name = name; version = version;} ''
+            mkdir -p $out/bin
+            ln -s ${program} $out/bin/.
           '';
           utils = system: (pkgs system).callPackage ./utils/rpm-deb {};
              in

--- a/utils/rpm-deb/default.nix
+++ b/utils/rpm-deb/default.nix
@@ -90,7 +90,7 @@ in {
 
       chmod -R a+rwx ./nix
       chmod -R a+rwx ./bin
-      fpm -s dir -t rpm --name ${pkg.name} nix bin
+      fpm -s dir -t rpm --name ${pkg.name} -v ${pkg.version} nix bin
     '';
 
     installPhase = ''
@@ -147,7 +147,7 @@ in {
 
       chmod -R a+rwx ./nix
       chmod -R a+rwx ./bin
-      fpm -s dir -t deb --name ${pkg.name} nix bin
+      fpm -s dir -t deb --name ${pkg.name} -v ${pkg.version} nix bin
     '';
 
     installPhase = ''


### PR DESCRIPTION
Currently the version of bundled package is always set to "1.0". It ignores the "version" parameter set in most packages. It would be convenient if the bundle name could match the version of its package.

This problem was also mentioned in [this issue](https://github.com/NixOS/bundlers/issues/10) in bundlers repo.
If you allow for this merge, I will open a pr in bundlers repo as well, in order to fix that issue.

This code introduces a new, optional parameter - "version", which is used in "buildFakeSingleRPM" and "buildFakeSingleDEB".